### PR TITLE
Added the Systems Design Primer to Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ But knowing the stuff will help you become better! :muscle:*
 - :movie_camera: [CQRS and Event Sourcing](https://www.youtube.com/watch?v=JHGkaShoyNs)
 - :book: [Practical Object Oriented Design in Ruby](http://www.poodr.com/)
 - :movie_camera: [Evolutionary Software Architectures](https://www.youtube.com/watch?v=CglSFhwbI3s)
+- [System Design: A Primer](https://github.com/donnemartin/system-design-primer)
 
 ### Practices
 - :book: [Working Effectively with Legacy Code](https://www.goodreads.com/book/show/44919.Working_Effectively_with_Legacy_Code)


### PR DESCRIPTION
A follow-up PR to the 39th issue: _[Add a link to the "System Design: A Primer" repository](https://github.com/mr-mig/every-programmer-should-know/issues/39)_.