### PR TITLE
Add algos visualization resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ But knowing the stuff will help you become better! :muscle:*
 - [Big O Cheatsheet](http://bigocheatsheet.com/)
 - :book: [Grokking Algorithms](https://www.goodreads.com/book/show/22847284-grokking-algorithms-an-illustrated-guide-for-programmers-and-other-curio)
 - [Sorting Algorithms](https://visualgo.net/en/sorting)
+- [Algorithms Visualization](http://www.cs.usfca.edu/~galles/visualization/Algorithms.html)
 
 ### Data Structures
 - :movie_camera: [UC Berkeley, Data Structures Course](https://archive.org/details/ucberkeley-webcast-PL-XXv-cvA_iAlnI-BQr9hjqADPBtujFJd)


### PR DESCRIPTION
Great resource where you can visualize and play with the most famous algos. In principal, you can even replace the previous resource `[Sorting Algorithms](https://visualgo.net/en/sorting)` with this one. 

visualgo.net is not only about sorting, other algos are included there also. But www.cs.usfca.edu looks like to be more handy.